### PR TITLE
fix the infinity loop bug encountered in the R->W dependency

### DIFF
--- a/src/controller.cc
+++ b/src/controller.cc
@@ -18,7 +18,7 @@ Controller::Controller(int channel, const Config &config, const Timing &timing)
       channel_state_(config, timing),
       cmd_queue_(channel_id_, config, channel_state_, simple_stats_),
       refresh_(config, channel_state_),
-      is_rw_denp_(false),
+      is_rw_dep_(false),
 #ifdef THERMAL
       thermal_calc_(thermal_calc),
 #endif  // THERMAL
@@ -197,7 +197,7 @@ bool Controller::AddTransaction(Transaction trans) {
 
 void Controller::ScheduleTransaction() {
     // determine whether to schedule read or write
-    if (is_rw_denp_ == false && write_draining_ == 0 && !is_unified_queue_) {
+    if (is_rw_dep_ == false && write_draining_ == 0 && !is_unified_queue_) {
         // we basically have a upper and lower threshold for write buffer
         if ((write_buffer_.size() >= write_buffer_.capacity()) ||
             (write_buffer_.size() > 8 && cmd_queue_.QueueEmpty())) {
@@ -216,12 +216,12 @@ void Controller::ScheduleTransaction() {
                 // Enforce R->W dependency
                 if (pending_rd_q_.count(it->addr) > 0) {
                     write_draining_ = 0;
-                    is_rw_denp_ = true;
+                    is_rw_dep_ = true;
                     break;
                 }
                 write_draining_ -= 1;
             }
-            is_rw_denp_ = false;
+            is_rw_dep_ = false;
             cmd_queue_.AddCommand(cmd);
             queue.erase(it);
             break;

--- a/src/controller.cc
+++ b/src/controller.cc
@@ -204,6 +204,7 @@ void Controller::ScheduleTransaction() {
             write_draining_ = write_buffer_.size();
         }
     }
+    is_rw_dep_ = false;
 
     std::vector<Transaction> &queue =
         is_unified_queue_ ? unified_queue_
@@ -221,7 +222,6 @@ void Controller::ScheduleTransaction() {
                 }
                 write_draining_ -= 1;
             }
-            is_rw_dep_ = false;
             cmd_queue_.AddCommand(cmd);
             queue.erase(it);
             break;

--- a/src/controller.cc
+++ b/src/controller.cc
@@ -18,6 +18,7 @@ Controller::Controller(int channel, const Config &config, const Timing &timing)
       channel_state_(config, timing),
       cmd_queue_(channel_id_, config, channel_state_, simple_stats_),
       refresh_(config, channel_state_),
+      is_rw_denp_(false),
 #ifdef THERMAL
       thermal_calc_(thermal_calc),
 #endif  // THERMAL
@@ -196,7 +197,7 @@ bool Controller::AddTransaction(Transaction trans) {
 
 void Controller::ScheduleTransaction() {
     // determine whether to schedule read or write
-    if (write_draining_ == 0 && !is_unified_queue_) {
+    if (is_rw_denp_ == false && write_draining_ == 0 && !is_unified_queue_) {
         // we basically have a upper and lower threshold for write buffer
         if ((write_buffer_.size() >= write_buffer_.capacity()) ||
             (write_buffer_.size() > 8 && cmd_queue_.QueueEmpty())) {
@@ -215,10 +216,12 @@ void Controller::ScheduleTransaction() {
                 // Enforce R->W dependency
                 if (pending_rd_q_.count(it->addr) > 0) {
                     write_draining_ = 0;
+                    is_rw_denp_ = true;
                     break;
                 }
                 write_draining_ -= 1;
             }
+            is_rw_denp_ = false;
             cmd_queue_.AddCommand(cmd);
             queue.erase(it);
             break;

--- a/src/controller.h
+++ b/src/controller.h
@@ -46,6 +46,7 @@ class Controller {
     ChannelState channel_state_;
     CommandQueue cmd_queue_;
     Refresh refresh_;
+    bool is_rw_dep_;
 
 #ifdef THERMAL
     ThermalCalculator &thermal_calc_;


### PR DESCRIPTION
Fix the BUG of infinity loop encountered in the R->W dependency. It should be handled prior to write. When the R->W dependency occurs, we should schedule read queue for the next cycle, which aims to serve the corresponding read request before the write, and the variable ' write_draining' should not be overwritten by the write buffer size.