### PR TITLE
Use external dependencies during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ release
 
 # IDEs / Editors
 .vscode/
+.cache/
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
-cmake_minimum_required(VERSION 3.0.0)
-project(dramsim3)
+cmake_minimum_required(VERSION 3.1)
+project(dramsim3 CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -26,7 +29,7 @@ add_library(json INTERFACE)
 target_include_directories(json INTERFACE ext/headers)
 
 # Main DRAMSim Lib
-add_library(dramsim3 SHARED
+add_library(dramsim3
     src/bankstate.cc
     src/channel_state.cc
     src/command_queue.cc
@@ -78,11 +81,8 @@ endif (ADDR_TRACE)
 
 target_include_directories(dramsim3 INTERFACE src)
 target_compile_options(dramsim3 PRIVATE -Wall)
-target_link_libraries(dramsim3 PRIVATE inih format)
+target_link_libraries(dramsim3 inih format)
 set_target_properties(dramsim3 PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
 
@@ -91,21 +91,18 @@ add_executable(dramsim3main src/main.cc src/cpu.cc)
 target_link_libraries(dramsim3main PRIVATE dramsim3 args)
 target_compile_options(dramsim3main PRIVATE)
 set_target_properties(dramsim3main PROPERTIES
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
 
 # Unit testing
-add_library(Catch INTERFACE)
-target_include_directories(Catch INTERFACE ext/headers)
+find_package(Catch2 3 REQUIRED)
 
 add_executable(dramsim3test EXCLUDE_FROM_ALL
     tests/test_config.cc
     tests/test_dramsys.cc
     tests/test_hmcsys.cc # IDK somehow this can literally crush your computer
 )
-target_link_libraries(dramsim3test Catch dramsim3)
+target_link_libraries(dramsim3test Catch2::Catch2WithMain dramsim3)
 target_include_directories(dramsim3test PRIVATE src/)
 
 # We have to use this custome command because there's a bug in cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,14 @@ endif()
 add_library(inih INTERFACE)
 target_include_directories(inih INTERFACE ext/headers)
 
-add_library(format INTERFACE)
-target_include_directories(format INTERFACE ext/fmt/include)
-target_compile_definitions(format INTERFACE FMT_HEADER_ONLY=1)
+find_package(fmt)
+if(NOT fmt_FOUND)
+    message(STATUS "External fmt package not found, using internal one")
+    add_library(fmt INTERFACE)
+    target_include_directories(fmt INTERFACE ext/fmt/include)
+    target_compile_definitions(fmt INTERFACE FMT_HEADER_ONLY=1)
+    add_library(fmt::fmt-header-only ALIAS fmt)
+endif(NOT fmt_FOUND)
 
 # argparsing library, only used in main program not the library
 add_library(args INTERFACE)
@@ -81,7 +86,7 @@ endif (ADDR_TRACE)
 
 target_include_directories(dramsim3 INTERFACE src)
 target_compile_options(dramsim3 PRIVATE -Wall)
-target_link_libraries(dramsim3 inih format)
+target_link_libraries(dramsim3 PRIVATE inih fmt::fmt-header-only)
 set_target_properties(dramsim3 PROPERTIES
     CXX_EXTENSIONS NO
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 project(dramsim3 CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/src/command_queue.cc
+++ b/src/command_queue.cc
@@ -115,7 +115,7 @@ bool CommandQueue::WillAcceptCommand(int rank, int bankgroup, int bank) const {
 }
 
 bool CommandQueue::QueueEmpty() const {
-    for (const auto q : queues_) {
+    for (const auto &q : queues_) {
         if (!q.empty()) {
             return false;
         }

--- a/src/common.cc
+++ b/src/common.cc
@@ -1,5 +1,5 @@
 #include "common.h"
-#include "fmt/format.h"
+#include <fmt/format.h>
 #include <sstream>
 #include <unordered_set>
 #include <sys/stat.h>

--- a/src/simple_stats.cc
+++ b/src/simple_stats.cc
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "fmt/format.h"
+#include <fmt/format.h>
 #include "simple_stats.h"
 
 namespace dramsim3 {

--- a/tests/test_config.cc
+++ b/tests/test_config.cc
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 #include "configuration.h"
 
 TEST_CASE("Address Mapping", "[config]") {

--- a/tests/test_dramsys.cc
+++ b/tests/test_dramsys.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 #include "configuration.h"
 #include "dram_system.h"
 

--- a/tests/test_hmcsys.cc
+++ b/tests/test_hmcsys.cc
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_test_macros.hpp>
 #include "configuration.h"
 #include "memory_system.h"
 


### PR DESCRIPTION
- Require external `catch2`, the internal one doesn't work with new compilers
- Allow external `fmt`, the internal one still works